### PR TITLE
Attempting to push batches into TAIL.

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -712,17 +712,8 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         Some(button)
                     }
                     SinkConnector::Tail(c) => {
-                        // Devolution code; batches could provide better methods for iteration.
-                        let collection = batches.flat_map(|batch| {
-                            let mut cursor = batch.cursor();
-                            let output = cursor.to_vec(&batch);
-                            output.into_iter().flat_map(|((row, ()), list)| {
-                                list.into_iter().map(move |(t, d)| (row.clone(), t, d))
-                            })
-                        });
-                        // TODO(cirego): Avoid devolution, change `tail` to take a stream of
-                        // batches, which are more easily enumerated in order.
-                        sink::tail(&collection, sink_id, c);
+                        // Unlike the other sinks, Tail accepts a stream of batches
+                        sink::tail(&batches, sink_id, c);
                         None
                     }
                     SinkConnector::AvroOcf(c) => {


### PR DESCRIPTION
Attempting to push batches into TAIL.

Currently fails to compile due to my not quite understanding how types
are converted across Timely boundaries. Just moving the devolution code
into `sink::tail` gives the following error:

    [E0599]: no method named `flat_map` found for enum `timely_communication::message::RefOrMut<'_, std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>>` in the current scope
    --> src/dataflow/src/sink/tail.rs:33:32
    |
    33  |               let rows = batches.flat_map(move |batch| {
    |                                  ^^^^^^^^ method not found in `timely_communication::message::RefOrMut<'_, std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>>`
    |
    ::: /home/chris/.cargo/git/checkouts/timely-dataflow-4c0cc365061cd263/76e6049/communication/src/message.rs:9:1
    |
    9   |   pub enum RefOrMut<'a, T> where T: 'a {
    |   ------------------------------------ doesn't satisfy `_: std::iter::Iterator`
    |
    = note: the method `flat_map` exists but the following trait bounds were not satisfied:
    `timely_communication::message::RefOrMut<'_, std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>>: std::iter::Iterator`
    which is required by `&mut timely_communication::message::RefOrMut<'_, std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>>: std::iter::Iterator`
    `std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>: std::iter::Iterator`
    which is required by `&mut std::vec::Vec<std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>: std::iter::Iterator`
    `[std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>]: std::iter::Iterator`
    which is required by `&mut [std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>]: std::iter::Iterator`

I have tried a few iterations on this. Namely:

Diff 1: Call `iter()` on batches. Compiler says:

    error[E0599]: no method named `iter` found for struct `std::iter::FlatMap<std::slice::Iter<'_, std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>, std::iter::FlatMap<std::vec::IntoIter<((repr::row::Row, ()), std::vec::Vec<(u64, isize)>)>, std::iter::Map<std::vec::IntoIter<(u64, isize)>, [closure@src/dataflow/src/sink/tail.rs:39:42: 39:75 row:_]>, [closure@src/dataflow/src/sink/tail.rs:38:45: 40:18]>, [closure@src/dataflow/src/sink/tail.rs:35:48: 41:14]>` in the current scope
    --> src/dataflow/src/sink/tail.rs:44:43
    |
    44 |             for (row, time, diff) in rows.iter() {
    |                                           ^^^^ method not found in `std::iter::FlatMap<std::slice::Iter<'_, std::rc::Rc<differential_dataflow::trace::implementations::ord::OrdKeyBatch<repr::row::Row, u64, isize>>>, std::iter::FlatMap<std::vec::IntoIter<((repr::row::Row, ()), std::vec::Vec<(u64, isize)>)>, std::iter::Map<std::vec::IntoIter<(u64, isize)>, [closure@src/dataflow/src/sink/tail.rs:39:42: 39:75 row:_]>, [closure@src/dataflow/src/sink/tail.rs:38:45: 40:18]>, [closure@src/dataflow/src/sink/tail.rs:35:48: 41:14]>`

Diff 2: Remove the call to `iter()` on rows. Compiler says:

    error[E0308]: mismatched types
    --> src/dataflow/src/sink/tail.rs:46:50
    |
    46 |                     connector.frontier.less_than(time)
    |                                                  ^^^^
    |                                                  |
    |                                                  expected `&u64`, found `u64`
    |                                                  help: consider borrowing here: `&time`

    error[E0308]: mismatched types
    --> src/dataflow/src/sink/tail.rs:48:51
    |
    48 |                     connector.frontier.less_equal(time)
    |                                                   ^^^^
    |                                                   |
    |                                                   expected `&u64`, found `u64`
    |                                                   help: consider borrowing here: `&time`

    error[E0614]: type `u64` cannot be dereferenced
    --> src/dataflow/src/sink/tail.rs:53:36
    |
    53 |                         timestamp: *time,
    |                                    ^^^^^

    error[E0614]: type `isize` cannot be dereferenced
    --> src/dataflow/src/sink/tail.rs:54:31
    |
    54 |                         diff: *diff,
    |                               ^^^^^

Diff 3: "Fix" those errors by adding "&" and removing "*". Compiler says:

    error[E0507]: cannot move out of `connector`, a captured variable in an `FnMut` closure
    --> src/dataflow/src/sink/tail.rs:34:24
    |
    28 |     connector: TailSinkConnector,
    |     --------- captured outer variable
    ...
    34 |         input.for_each(move |_, batches| {
    |                        ^^^^^^^^^^^^^^^^^ move out of `connector` occurs here
    ...
    45 |                 let should_emit = if connector.strict {
    |                                      ---------
    |                                      |
    |                                      move occurs because `connector` has type `dataflow_types::types::TailSinkConnector`, which does not implement the `Copy` trait
    |                                      move occurs due to use in closure

    error[E0507]: cannot move out of `tx`, a captured variable in an `FnMut` closure
    --> src/dataflow/src/sink/tail.rs:34:24
    |
    32 |     let mut tx = block_on(connector.tx.connect()).expect("tail transmitter failed");
    |         ------ captured outer variable
    33 |     stream.sink(Pipeline, &format!("tail-{}", id), move |input| {
    34 |         input.for_each(move |_, batches| {
    |                        ^^^^^^^^^^^^^^^^^ move out of `tx` occurs here
    ...
    63 |             block_on(tx.send(results)).expect("tail send failed");
    |                      --
    |                      |
    |                      move occurs because `tx` has type `std::pin::Pin<std::boxed::Box<dyn futures_sink::Sink<std::vec::Vec<dataflow_types::types::Update>, Error = comm::error::Error> + std::marker::Send>>`, which does not implement the `Copy` trait
    |                      move occurs due to use in closure

And now I'm pretty sure I'm just going down the wrong path, not
understanding something simple from the first part of the patch.